### PR TITLE
Update ndarray version to be able to use in Windows PC (Intel-MKL).

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,14 +18,14 @@ static    = ["ndarray-linalg/openblas-static",  "fftw/source"]
 intel-mkl = ["ndarray-linalg/intel-mkl", "fftw/intel-mkl"]
 
 [dependencies]
-num-traits  = { version = "0.2",  default-features = false }
-num-complex = { version = "0.2",  default-features = false }
+num-traits  = { version = "0.2.11",  default-features = false }
+num-complex = { version = "0.2.4",  default-features = false }
 derive-new  = { version = "0.5",  default-features = false }
-ndarray     = { version = "0.12", default-features = false }
+ndarray     = { version = "0.13", default-features = false }
 fftw        = { version = "0.6",  default-features = false }
 
 [dependencies.ndarray-linalg]
-version = "0.11"
+version = "0.12"
 git = "https://github.com/rust-ndarray/ndarray-linalg"
 default-features = false
 

--- a/src/adaptor.rs
+++ b/src/adaptor.rs
@@ -43,7 +43,7 @@ pub fn iterate<S, TEO>(
     step: usize,
 ) -> ArrayBase<S, TEO::Dim>
 where
-    S: DataMut<Elem = TEO::Scalar> + DataClone,
+    S: DataMut<Elem = TEO::Scalar> + Data + RawDataClone,
     TEO: TimeEvolution,
 {
     teo.iterate_n(&mut x0, step);
@@ -55,7 +55,7 @@ where
 /// [time_series]: fn.time_series.html
 pub struct TimeSeries<'a, S, TEO>
 where
-    S: DataMut<Elem = TEO::Scalar> + DataClone,
+    S: DataMut<Elem = TEO::Scalar> + Data + RawDataClone,
     TEO: TimeEvolution + 'a,
 {
     state: ArrayBase<S, TEO::Dim>,
@@ -94,7 +94,7 @@ pub fn time_series<'a, S, TEO>(
     teo: &'a mut TEO,
 ) -> TimeSeries<'a, S, TEO>
 where
-    S: DataMut<Elem = TEO::Scalar> + DataClone,
+    S: DataMut<Elem = TEO::Scalar> + Data + RawDataClone,
     TEO: TimeEvolution,
 {
     TimeSeries {
@@ -105,7 +105,7 @@ where
 
 impl<'a, S, TEO> TimeSeries<'a, S, TEO>
 where
-    S: DataMut<Elem = TEO::Scalar> + DataClone,
+    S: DataMut<Elem = TEO::Scalar> + Data + RawDataClone,
     TEO: TimeEvolution,
 {
     pub fn iterate(&mut self) {
@@ -115,7 +115,7 @@ where
 
 impl<'a, S, TEO> Iterator for TimeSeries<'a, S, TEO>
 where
-    S: DataMut<Elem = TEO::Scalar> + DataClone,
+    S: DataMut<Elem = TEO::Scalar> + Data + RawDataClone,
     TEO: TimeEvolution,
 {
     type Item = ArrayBase<S, TEO::Dim>;

--- a/src/lyapunov.rs
+++ b/src/lyapunov.rs
@@ -123,7 +123,7 @@ where
         .skip(duration / 10)
         .take(duration)
         .fold(ArrayBase::zeros(n), |mut x, y| {
-            azip!(mut x, y in { *x = *x + y/dur } );
+            azip!((x in &mut x, &y in &y) *x = *x + y/dur );
             x
         })
 }
@@ -179,7 +179,7 @@ fn clv_backward<A: Scalar + Lapack>(c: &Array2<A>, r: &Array2<A>) -> (Array2<A>,
         .solve_triangular(UPLO::Upper, ::ndarray_linalg::Diag::NonUnit, c)
         .expect("Failed to solve R");
     let (c, d) = normalize(cd, NormalizeAxis::Column);
-    let f = Array::from_vec(d).mapv_into(|x| A::Real::one() / x);
+    let f = Array::from(d).mapv_into(|x| A::Real::one() / x);
     (c, f)
 }
 

--- a/src/ode/lorenz63.rs
+++ b/src/ode/lorenz63.rs
@@ -67,6 +67,6 @@ impl SemiImplicit for Lorenz63 {
     }
 
     fn diag(&self) -> Array<f64, Ix1> {
-        Array::from_vec(vec![-self.p, -1.0, -self.b])
+        Array::from(vec![-self.p, -1.0, -self.b])
     }
 }

--- a/src/pde/kse.rs
+++ b/src/pde/kse.rs
@@ -6,6 +6,7 @@
 use fftw::types::c64;
 use ndarray::*;
 use std::f64::consts::PI;
+use std::iter::FromIterator;
 
 use super::Pair;
 use crate::traits::*;
@@ -57,13 +58,13 @@ impl SemiImplicit for KSE {
     where
         S: DataMut<Elem = Self::Scalar>,
     {
-        azip!(mut u(self.u.coeff_view_mut()), mut ux(self.ux.coeff_view_mut()), k(&self.k), uf(&*uf) in {
+        azip!((u in &mut self.u.coeff_view_mut(), ux in &mut self.ux.coeff_view_mut(), &k in &self.k, &uf in &*uf) {
             *u = uf;
             *ux = k * uf;
         });
         self.u.c2r();
         self.ux.c2r();
-        azip!(mut u(self.u.real_view_mut()), ux(self.ux.real_view()) in {
+        azip!((u in &mut self.u.real_view_mut(), &ux in &self.ux.real_view()) {
             *u = -*u * ux;
         });
         self.u.r2c();

--- a/src/pde/she.rs
+++ b/src/pde/she.rs
@@ -1,6 +1,7 @@
 use fftw::types::c64;
 use ndarray::*;
 use std::f64::consts::PI;
+use std::iter::FromIterator;
 
 use super::Pair;
 use crate::traits::*;
@@ -58,11 +59,11 @@ impl SemiImplicit for SWE {
         let c2 = 1.64;
         let c3 = 1.0;
 
-        azip!(mut u(self.u.coeff_view_mut()), uf(&*uf) in {
+        azip!((u in &mut self.u.coeff_view_mut(), &uf in &*uf) {
             *u = uf;
         });
         self.u.c2r();
-        azip!(mut u(self.u.real_view_mut()) in {
+        azip!((u in &mut self.u.real_view_mut()) {
             *u = c2 * *u * *u - c3 * *u * *u * *u;
         });
         self.u.r2c();

--- a/tests/pde.rs
+++ b/tests/pde.rs
@@ -1,6 +1,7 @@
 use ndarray::*;
 use ndarray_linalg::*;
 use std::f64::consts::PI;
+use std::iter::FromIterator;
 
 use eom::pde::*;
 

--- a/tests/view.rs
+++ b/tests/view.rs
@@ -19,7 +19,7 @@ fn rcarr() {
     let dt = 0.01;
     let eom = ode::Lorenz63::default();
     let mut teo = explicit::Euler::new(eom, dt);
-    let mut x: RcArray1<f64> = rcarr1(&[1.0, 0.0, 0.0]);
+    let mut x: ArcArray<f64, Ix1> = rcarr1(&[1.0, 0.0, 0.0]);
     teo.iterate(&mut x);
 }
 


### PR DESCRIPTION
I updated ndarray and ndarray-linalg version because I want to use this crate in Windows (Intel-MKL).
Then, I rewrote some deprecated traits(DataClone) and syntax(azip!, from_vec).